### PR TITLE
demo: blinkled, P9_14 is used by new default proto cape, use P9_11 intea...

### DIFF
--- a/demo/blinkled.js
+++ b/demo/blinkled.js
@@ -1,6 +1,6 @@
 var b = require('bonescript');
 
-var ledPin = "P9_14";
+var ledPin = "P9_11";
 var ledPin2 = "USR3";
 
 b.pinMode(ledPin, b.OUTPUT);


### PR DESCRIPTION
The new default pinmux for the proto cape uses P9_14, lets move this demo to P9_11. Tested in c9/ide.